### PR TITLE
Fixed #7

### DIFF
--- a/remcoder:chronos.js
+++ b/remcoder:chronos.js
@@ -47,7 +47,7 @@ function liveUpdate(interval) {
   // make sure to stop and delete the attached timer when the computation is stopped
   comp.onInvalidate(function() {
     //console.log('onInvalidated',comp);
-    if (comp.stopped) {
+    if (comp.stopped && _timers[cid]) {
       //console.log('computation stopped');
       _timers[cid].destroy();
     }


### PR DESCRIPTION
Found that `comp.invalidate` was being called twice and failing the second time because `_timers[cid]` had already been removed by then.
